### PR TITLE
ios: remove generated xcworkspace

### DIFF
--- a/ios/ComboSample/.gitignore
+++ b/ios/ComboSample/.gitignore
@@ -20,3 +20,4 @@ DerivedData
 
 Pods
 Podfile.lock
+ComboSample.xckworkspace

--- a/ios/ComboSample/ComboSample.xcworkspace/contents.xcworkspacedata
+++ b/ios/ComboSample/ComboSample.xcworkspace/contents.xcworkspacedata
@@ -1,1 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?><Workspace version='1.0'><FileRef location='group:ComboSample.xcodeproj'/><FileRef location='group:Pods/Pods.xcodeproj'/></Workspace>


### PR DESCRIPTION
The README [instructions](https://github.com/playgameservices/cpp-crossplatform-minimal-sample/blob/master/README.md#ios) points out that this file is generated, so it probably shouldn't be checked-in.
